### PR TITLE
Display actual weather icon images in TaskBox using ImageIcons

### DIFF
--- a/src/main/java/view/TaskBox.java
+++ b/src/main/java/view/TaskBox.java
@@ -232,4 +232,22 @@ public class TaskBox extends JPanel implements PropertyChangeListener {
     public ViewManagerModel getViewManagerModel() {
         return viewManagerModel;
     }
+
+    private ImageIcon loadWeatherIcon(String iconName) {
+        String iconPath = "/weatherIcons/" + iconName + ".png"; // Make sure this matches your resource folder
+
+        try {
+            java.net.URL imgURL = getClass().getResource(iconPath);
+            if (imgURL != null) {
+                Image img = new ImageIcon(imgURL).getImage();
+                Image scaledImg = img.getScaledInstance(30, 30, Image.SCALE_SMOOTH);
+                return new ImageIcon(scaledImg);
+            } else {
+                System.err.println("Couldn't find icon: " + iconPath);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
 }

--- a/src/main/java/view/TaskBox.java
+++ b/src/main/java/view/TaskBox.java
@@ -209,7 +209,20 @@ public class TaskBox extends JPanel implements PropertyChangeListener {
         tempLabel.setText(taskViewModel.getTask().getTaskInfo().getTemperature());
 
         weatherDescriptionLabel.setText(taskViewModel.getTask().getTaskInfo().getWeatherDescription());
-        weatherEmojiLabel.setText(taskViewModel.getTask().getTaskInfo().getWeatherIconName());
+        String iconName = taskViewModel.getTask().getTaskInfo().getWeatherIconName();
+        if (iconName != null && !iconName.isEmpty()) {
+            ImageIcon icon = loadWeatherIcon(iconName);
+            if (icon != null) {
+                weatherEmojiLabel.setIcon(icon);
+                weatherEmojiLabel.setText(""); // Clear leftover text
+            } else {
+                weatherEmojiLabel.setText(iconName); // Fallback to text if not found
+            }
+        } else {
+            weatherEmojiLabel.setIcon(null);
+            weatherEmojiLabel.setText("");
+        }
+
 
         updateDisplayColour();
 


### PR DESCRIPTION
This PR replaces the text-based weather icon representation in ```TaskBox``` with actual icon images (PNG) loaded from the ```weatherIcons``` resource folder.

 - Uses ```weatherIconName``` field from ```TaskInfo``` to load the appropriate icon (e.g., ```"clear-day"``` loads ```weatherIcons/clear-day.png```).
 - Updates ```TaskBox``` to render the icon using ```ImageIcon``` instead of ```JLabel.setText(...)```.
 - Includes a helper method ```loadWeatherIcon(...)``` for image scaling and loading.