### PR TITLE
Refresh Calendar View After Adding Task

### DIFF
--- a/src/main/java/app/AddTaskUseCaseFactory.java
+++ b/src/main/java/app/AddTaskUseCaseFactory.java
@@ -6,6 +6,7 @@ import interface_adapter.addTask.AddTaskController;
 import interface_adapter.addTask.AddTaskPresenter;
 import interface_adapter.addTask.AddTaskViewModel;
 import interface_adapter.addTask.UUIDGenerator;
+import interface_adapter.logged_in.LoggedInViewModel;
 import use_case.addTask.AddTaskInputBoundary;
 import use_case.addTask.AddTaskInteractor;
 import data_access.SupabaseTaskDataAccessObject;
@@ -19,6 +20,7 @@ public final class AddTaskUseCaseFactory {
     public static AddTaskView create(
             ViewManagerModel viewManagerModel,
             AddTaskViewModel addTaskViewModel,
+            LoggedInViewModel loggedInViewModel,
             TaskDataAccessInterface taskDao,
             WeatherApiService weatherApiService,
             String mainViewKey) {
@@ -31,6 +33,6 @@ public final class AddTaskUseCaseFactory {
         AddTaskController addTaskController = new AddTaskController(addTaskInteractor,
                 viewManagerModel, addTaskViewModel);
 
-        return new AddTaskView(addTaskController, addTaskViewModel, viewManagerModel);
+        return new AddTaskView(addTaskController, addTaskViewModel, loggedInViewModel, viewManagerModel);
     }
 }

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -105,6 +105,7 @@ public class AppBuilder {
             addTaskView = AddTaskUseCaseFactory.create(
                     viewManagerModel,
                     addTaskViewModel,
+                    loggedInViewModel,
                     taskDao,
                     new WeatherApiService(),
                     LoggedInView.getViewName()

--- a/src/main/java/view/AddTaskView.java
+++ b/src/main/java/view/AddTaskView.java
@@ -7,6 +7,7 @@ import interface_adapter.ViewManagerModel;
 import interface_adapter.addTask.AddTaskController;
 import interface_adapter.addTask.AddTaskViewModel;
 import interface_adapter.addTask.AddTaskState;
+import interface_adapter.logged_in.LoggedInViewModel;
 
 import javax.swing.*;
 import java.awt.*;
@@ -14,6 +15,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
@@ -24,6 +26,7 @@ public class AddTaskView extends JPanel
 
     private final AddTaskController controller;
     private final AddTaskViewModel  viewModel;
+    private final LoggedInViewModel loggedInViewModel;
     private final ViewManagerModel viewManagerModel;
     private final String mainViewKey;
     private static final String viewName = "Add Task";
@@ -41,10 +44,12 @@ public class AddTaskView extends JPanel
 
     public AddTaskView(AddTaskController controller,
                        AddTaskViewModel viewModel,
+                       LoggedInViewModel loggedInViewModel,
                        ViewManagerModel viewManagerModel) {
         this.controller = controller;
         this.viewModel  = viewModel;
         this.viewModel.addPropertyChangeListener(this);
+        this.loggedInViewModel = loggedInViewModel;
         this.viewManagerModel = viewManagerModel;
         this.mainViewKey = LoggedInView.getViewName();
         this.viewModel.addPropertyChangeListener(this);
@@ -177,17 +182,20 @@ public class AddTaskView extends JPanel
             errorLabel.setText(msg);
             errorLabel.setVisible(msg != null && !msg.isBlank());
         }
-        if ("taskAdded".equals(propertyName)) {            // ← only respond on success
-            if (st.isTaskAdded()) {
-                JOptionPane.showMessageDialog(
-                        SwingUtilities.getWindowAncestor(this),
-                        "Task added successfully!",
-                        "Success",
-                        JOptionPane.INFORMATION_MESSAGE
-                );
-                resetForm();
-                goBackToCalendarView();
-            }
+        if ("taskAdded".equals(propertyName) && st.isTaskAdded()) {
+            JOptionPane.showMessageDialog(
+                    SwingUtilities.getWindowAncestor(this),
+                    "Task added successfully!",
+                    "Success",
+                    JOptionPane.INFORMATION_MESSAGE
+            );
+            resetForm();
+            goBackToCalendarView();
+
+            LocalDate today = LocalDate.now();
+            LocalDate startOfWeek = today.minusDays(today.getDayOfWeek().getValue() % 7);
+            LocalDate endOfWeek = startOfWeek.plusDays(6);
+            loggedInViewModel.loadTasksForWeek(startOfWeek, endOfWeek);
         }
         if ("refreshTagOptions".equals(propertyName)) {
             Object newValue = evt.getNewValue();

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -112,10 +112,6 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
             this.hourlyWeatherMap = getHourlyWeatherMapForCalendarData(calendarData);
         }
 
-        LocalDate startDate = this.calendarData.getWeekDates().getFirst();
-        LocalDate endDate = startDate.plusDays(7);
-        loggedInViewModel.loadTasksForWeek(startDate,endDate);
-
         // --- Bottom: Logout + Add Task Buttons ---
         JButton logoutButton = new JButton("Log Out");
         JButton addTaskButton = new JButton("+ Add Task");
@@ -239,6 +235,14 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
             this.loggedInUsername = state.getUsername();
             usernameLabel.setText("Signed in as: " + this.loggedInUsername);
             // TODO: Brad, this is how you get the email: 'state.getEmail()'
+
+            // We load the tasks ONLY once the username is known
+            LocalDate today = LocalDate.now();
+            LocalDate startOfWeek = today.minusDays(today.getDayOfWeek().getValue() % 7);
+            LocalDate endOfWeek = startOfWeek.plusDays(6);
+            System.out.println("Now loading tasks for: " + loggedInUsername);
+            System.out.println("Date range: " + startOfWeek + " to " + endOfWeek);
+            loggedInViewModel.loadTasksForWeek(startOfWeek, endOfWeek);
         }
         else if ("weekTasks".equals(evt.getPropertyName())) {
             List<Task> tasks = loggedInViewModel.getState().getWeekTasks();

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -236,18 +236,23 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
             usernameLabel.setText("Signed in as: " + this.loggedInUsername);
             // TODO: Brad, this is how you get the email: 'state.getEmail()'
 
-            // We load the tasks ONLY once the username is known
-            LocalDate today = LocalDate.now();
-            LocalDate startOfWeek = today.minusDays(today.getDayOfWeek().getValue() % 7);
-            LocalDate endOfWeek = startOfWeek.plusDays(6);
             System.out.println("Now loading tasks for: " + loggedInUsername);
-            System.out.println("Date range: " + startOfWeek + " to " + endOfWeek);
-            loggedInViewModel.loadTasksForWeek(startOfWeek, endOfWeek);
+            reloadTasksForCurrentWeek();
         }
         else if ("weekTasks".equals(evt.getPropertyName())) {
             List<Task> tasks = loggedInViewModel.getState().getWeekTasks();
             rebuildCalendarWithTasks(tasks);
+        } else if ("taskAdded".equals(evt.getPropertyName())) {
+            System.out.println("Detected new task added. Reloading tasks...");
+            reloadTasksForCurrentWeek();
         }
+    }
+
+    private void reloadTasksForCurrentWeek() {
+        LocalDate startOfWeek = calendarData.getWeekDates().getFirst();
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+        System.out.println("Reloading tasks for week: " + startOfWeek + " to " + endOfWeek);
+        loggedInViewModel.loadTasksForWeek(startOfWeek, endOfWeek);
     }
 
     public static String getViewName() {


### PR DESCRIPTION
This PR ensures that after a user adds a task using ```AddTaskView```, the calendar (```LoggedInView```) immediately reflects the newly added task. It achieves this by triggering a reload of tasks from Supabase for the current calendar week and notifying the calendar view through ViewModel updates.