### PR TITLE
Made calendar task buttons span the hours they cover.

### DIFF
--- a/src/main/java/view/CalendarGrid.java
+++ b/src/main/java/view/CalendarGrid.java
@@ -7,7 +7,9 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionListener;
+import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.TextStyle;
 import java.util.*;
 import java.util.List;
@@ -26,117 +28,134 @@ public class CalendarGrid extends JPanel {
                         ActionListener manageTagsListener,
                         ActionListener logoutListener) {
 
+        super(new GridBagLayout());
         this.addTaskListener = addTaskListener;
         this.manageTagsListener = manageTagsListener;
         this.logoutListener = logoutListener;
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(1,1,1,1);
 
-        setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         List<LocalDate> weekDates = data.getWeekDates();
 
-        Map<LocalDate, Map<Integer, List<Task>>> taskMap = new HashMap<>();
+        // compute which date/hour cells are covered by spanning tasks
+        Set<String> covered = new HashSet<>();
         for (Task t : tasks) {
-            LocalDate date = t.getTaskInfo().getStartDateTime().toLocalDate();
-            int hour = t.getTaskInfo().getStartDateTime().getHour();
-            taskMap
-                    .computeIfAbsent(date, d -> new HashMap<>())
-                    .computeIfAbsent(hour, h -> new ArrayList<>())
-                    .add(t);
+            LocalDateTime s = t.getTaskInfo().getStartDateTime();
+            LocalDateTime e = t.getTaskInfo().getEndDateTime();
+            LocalDate date = s.toLocalDate();
+            int startHour = s.getHour();
+            int endHour   = e.getHour();
+            for (int h = startHour; h < endHour; h++) {
+                covered.add(date.toString() + "#" + h);
+            }
         }
 
-        for (int row = 0; row < 26; row++) {
-            JPanel rowPanel = new JPanel();
-            rowPanel.setLayout(new GridLayout(1, 8));
-            int rowHeight = (row == 1) ? 80 : 40;
-            rowPanel.setPreferredSize(new Dimension(800, rowHeight));
+        // --- Row 0: headers (empty corner + days/weather) ---
+        for (int col = 0; col < 8; col++) {
+            gbc.gridx = col;
+            gbc.gridy = 0;
+            gbc.gridwidth  = 1;
+            gbc.gridheight = 1;
+            gbc.weightx = (col == 0 ? 0.0 : 1.0);
+            gbc.weighty = 0.0;
+            gbc.fill    = GridBagConstraints.BOTH;
 
+            if (col == 0) {
+                add(new JLabel(""), gbc);
+            } else {
+                LocalDate date = weekDates.get(col - 1);
+                JPanel header = new JPanel(new BorderLayout());
+                header.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+
+                String dayName = date.getDayOfWeek()
+                        .getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
+                String fullDay = dayName + " the " + getOrdinal(date.getDayOfMonth());
+                JLabel dayLabel = new JLabel(fullDay, SwingConstants.CENTER);
+                dayLabel.setFont(dayLabel.getFont().deriveFont(Font.BOLD, 14f));
+                header.add(dayLabel, BorderLayout.NORTH);
+
+                Map<String, Object> weather = weatherMap.get(date);
+                JLabel iconLabel = new JLabel();
+                if (weather != null && weather.get("icon") != null) {
+                    iconLabel.setIcon((ImageIcon) weather.get("icon"));
+                }
+                iconLabel.setHorizontalAlignment(SwingConstants.CENTER);
+                header.add(iconLabel, BorderLayout.CENTER);
+
+                JPanel tempsPanel = new JPanel(new GridLayout(1,2));
+                tempsPanel.setPreferredSize(new Dimension(0,20));
+                if (weather != null) {
+                    tempsPanel.add(new JLabel(
+                            String.format("%.1f°C", (double)weather.get("tempmin")),
+                            SwingConstants.CENTER));
+                    tempsPanel.add(new JLabel(
+                            String.format("%.1f°C", (double)weather.get("tempmax")),
+                            SwingConstants.CENTER));
+                }
+                header.add(tempsPanel, BorderLayout.SOUTH);
+
+                add(header, gbc);
+            }
+        }
+
+        // --- Rows 1–24: first draw empty cells (to get borders) ---
+        for (int hour = 0; hour < 24; hour++) {
+            int row = hour + 1;
             for (int col = 0; col < 8; col++) {
+                gbc.gridx      = col;
+                gbc.gridy      = row;
+                gbc.gridwidth  = 1;
+                gbc.gridheight = 1;
+                gbc.weightx    = (col == 0 ? 0.0 : 1.0);
+                gbc.weighty    = 1.0;
+                gbc.fill       = GridBagConstraints.BOTH;
+
                 JPanel cell = new JPanel();
-
-                if (row == 0) {
-                    cell.setBorder(null);
-                    if (col == 0) {
-                        cell.add(new JLabel(""));
-                    }
-                } else if (row == 1) {
-                    cell.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-                    if (col == 0) {
-                        JButton menuButton = new JButton("☰");
-                        menuButton.addActionListener(e -> showSideMenu(menuButton));
-                        cell.add(menuButton);
-                    } else {
-                        LocalDate date = weekDates.get(col - 1);
-                        Map<String, Object> weather = weatherMap.get(date);
-                        cell.setLayout(new BorderLayout());
-
-                        // Updated: Top - Day name with number, like "Sun the 28th"
-                        String dayName = date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
-                        int dayOfMonth = date.getDayOfMonth();
-                        String fullDay = dayName + " the " + getOrdinal(dayOfMonth);
-                        JLabel dayLabel = new JLabel(fullDay);
-                        dayLabel.setHorizontalAlignment(SwingConstants.CENTER);
-                        dayLabel.setFont(dayLabel.getFont().deriveFont(Font.BOLD, 14f));
-                        cell.add(dayLabel, BorderLayout.NORTH);
-
-                        // Center: Weather icon
-                        JLabel iconLabel = new JLabel();
-                        ImageIcon icon = (ImageIcon) weather.get("icon");
-                        if (icon != null) {
-                            iconLabel.setIcon((ImageIcon) weather.get("icon"));
-                        }
-                        iconLabel.setHorizontalAlignment(SwingConstants.CENTER);
-                        cell.add(iconLabel, BorderLayout.CENTER);
-
-                        // Bottom: Temps
-                        JPanel tempsPanel = new JPanel(new GridLayout(1, 2));
-                        tempsPanel.setPreferredSize(new Dimension(cell.getWidth(), 20));
-
-                        double tempMin = (double) weather.get("tempmin");
-                        double tempMax = (double) weather.get("tempmax");
-
-                        JLabel lowLabel = new JLabel(String.format("%.1f°C", tempMin));
-                        lowLabel.setHorizontalAlignment(SwingConstants.CENTER);
-                        lowLabel.setFont(lowLabel.getFont().deriveFont(Font.PLAIN, 12f));
-
-                        JLabel highLabel = new JLabel(String.format("%.1f°C", tempMax));
-                        highLabel.setHorizontalAlignment(SwingConstants.CENTER);
-                        highLabel.setFont(highLabel.getFont().deriveFont(Font.PLAIN, 12f));
-
-                        tempsPanel.add(lowLabel);
-                        tempsPanel.add(highLabel);
-
-                        cell.add(tempsPanel, BorderLayout.SOUTH);
-                    }
-                } else if (col > 0){
-                    LocalDate date = weekDates.get(col - 1);
-                    int hour = row - 2;
-                    List<Task> cellTasks =
-                            taskMap.getOrDefault(date, Collections.emptyMap())
-                            .getOrDefault(hour, Collections.emptyList());
-
-                    if (!cellTasks.isEmpty()) {
-                        cell.setLayout(new FlowLayout(FlowLayout.LEFT, 2, 2));
-                        for (Task t : cellTasks) {
-                            if (!"Yes".equalsIgnoreCase(t.getTaskInfo().getIsDeleted())) {
-                                JButton button = getJButton(taskClickListener, t);
-                                cell.add(button);
-                            }
-
-                        }
-                    }
+                cell.setOpaque(false);
+                String key = (col > 0 ? weekDates.get(col-1).toString() + "#" + hour : null);
+                if (col == 0 || (key != null && !covered.contains(key))) {
                     cell.setBorder(BorderFactory.createLineBorder(Color.BLACK));
                 }
-                else {
-                    cell.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-                    cell.setLayout(new BoxLayout(cell, BoxLayout.Y_AXIS));
-                    JLabel hourLabel = new JLabel(CalendarData.HOURS_OF_DAY[row - 2]);
-                    hourLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+                if (col == 0) {
+                    // hour label column
+                    cell.setLayout(new GridBagLayout());
+                    JLabel hourLabel = new JLabel(
+                            CalendarData.HOURS_OF_DAY[hour],
+                            SwingConstants.CENTER);
                     cell.add(hourLabel);
                 }
+                // else: leave empty for now
 
-                rowPanel.add(cell);
+                add(cell, gbc);
             }
+        }
 
-            add(rowPanel);
+        // --- Then overlay each task button, spanning its rows ---
+        for (Task t : tasks) {
+            LocalDateTime start = t.getTaskInfo().getStartDateTime();
+            LocalDateTime end   = t.getTaskInfo().getEndDateTime();
+
+            int dayOfWeekVal = start.getDayOfWeek().getValue() % 7; // Sunday=0 .. Saturday=6
+            int col = dayOfWeekVal + 1;                            // gridx=1..7
+            int row = start.getHour() + 1;  // gridy=1..24
+
+            long durationHrs = Math.max(1,
+                    Duration.between(start, end).toHours());
+            int span = (int)durationHrs;
+
+            JButton btn = getJButton(taskClickListener, t);
+
+            gbc.gridx      = col;
+            gbc.gridy      = row;
+            gbc.gridheight = span;
+            gbc.weightx    = 1.0;
+            gbc.weighty    = span;
+            gbc.fill       = GridBagConstraints.BOTH;
+
+            // Remove border on the blank cell underneath:
+            // (optional) you might want btn.setBorder(null);
+            add(btn, gbc);
         }
     }
 


### PR DESCRIPTION
Edited CalendarGrid to make the task buttons on the calendar fill and span the hours that the task is covering. 

**Remaining Issue:**
Currently, the button will start from the hour equal to the start date hour value (e.g. 2:59 starts from 2:00) and ends at the hour equal to the end date hour value (e.g. if ends at 2:59 the button only goes to 2:00). 

**Proposed Fix:**
Considering update to make the resolution of the calendar to the quarter hour. This way, we can have the button spanning more accurate time intervals based on start and end time. Will do on another branch.