### PR TITLE
refactored logic for replacing tags in EditTagInteractor

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -26,6 +26,8 @@ import interface_adapter.markTaskComplete.MarkTaskCompleteViewModel;
 import interface_adapter.signup.SignupViewModel;
 import interface_adapter.task.TaskBoxDependencies;
 
+import use_case.edit_custom_tag.tagReplacement.DeleteAndCreate;
+import use_case.edit_custom_tag.tagReplacement.TagReplacementStrategy;
 import use_case.notification.EmailNotificationServiceInterface;
 import use_case.notification.NotificationDataAccessInterface;
 import use_case.notification.ScheduleNotificationInteractor;
@@ -75,6 +77,7 @@ public final class AppBuilder {
     private final Map<String, JPanel> viewMap = new HashMap<>();
 
     private final WeatherApiService weatherApiService = new WeatherApiService();
+    private final TagReplacementStrategy replacementStrategy = new DeleteAndCreate();
 
     private SupabaseUserDataAccessObject userDao;
     private SupabaseTagDataAccessObject tagDao;
@@ -363,7 +366,8 @@ public final class AppBuilder {
                     viewManagerModel,
                     editTagViewModel,
                     manageTagsViewModel,
-                    tagDao
+                    tagDao,
+                    replacementStrategy
             );
             cardPanel.add(editTagView, EditTagView.getViewName());
             viewMap.put(EditTagView.getViewName(), editTagView);

--- a/src/main/java/app/EditTagUseCaseFactory.java
+++ b/src/main/java/app/EditTagUseCaseFactory.java
@@ -11,6 +11,7 @@ import use_case.edit_custom_tag.EditTagInputBoundary;
 import use_case.edit_custom_tag.EditTagInteractor;
 import use_case.edit_custom_tag.EditTagOutputBoundary;
 
+import use_case.edit_custom_tag.tagReplacement.TagReplacementStrategy;
 import view.EditTagView;
 
 /**
@@ -35,10 +36,11 @@ public final class EditTagUseCaseFactory {
             final ViewManagerModel viewManagerModel,
             final EditTagViewModel viewModel,
             final ManageTagsViewModel manageTagsViewModel,
-            final CustomTagDataAccessInterface customTagDataAccessInterface
+            final CustomTagDataAccessInterface customTagDataAccessInterface,
+            final TagReplacementStrategy replacementStrategy
     ) {
         final EditTagController controller = createEditTagUseCase(viewManagerModel, viewModel,
-                manageTagsViewModel, customTagDataAccessInterface);
+                manageTagsViewModel, customTagDataAccessInterface, replacementStrategy);
         return new EditTagView(viewManagerModel, manageTagsViewModel, viewModel, controller);
     }
 
@@ -55,10 +57,11 @@ public final class EditTagUseCaseFactory {
             final ViewManagerModel viewManagerModel,
             final EditTagViewModel viewModel,
             final ManageTagsViewModel manageTagsViewModel,
-            final CustomTagDataAccessInterface tagDao
+            final CustomTagDataAccessInterface tagDao,
+            final TagReplacementStrategy replacementStrategy
     ) {
         final EditTagOutputBoundary presenter = new EditTagPresenter(viewManagerModel, viewModel, manageTagsViewModel);
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, replacementStrategy);
         return new EditTagController(tagDao, manageTagsViewModel, interactor);
     }
 }

--- a/src/main/java/view/CreateCustomTagView.java
+++ b/src/main/java/view/CreateCustomTagView.java
@@ -326,7 +326,7 @@ public class CreateCustomTagView extends JPanel implements PropertyChangeListene
 
         resetForm();
 
-        viewManagerModel.setState(LoggedInView.getViewName());
+        viewManagerModel.setState(ManageTagsView.getViewName());
         viewManagerModel.firePropertyChanged();
     }
 

--- a/src/test/java/use_case/EditTag/EditTagInteractorTest.java
+++ b/src/test/java/use_case/EditTag/EditTagInteractorTest.java
@@ -11,6 +11,7 @@ import use_case.edit_custom_tag.EditTagInputBoundary;
 import use_case.edit_custom_tag.EditTagInteractor;
 import use_case.edit_custom_tag.EditTagOutputBoundary;
 import use_case.edit_custom_tag.EditTagOutputData;
+import use_case.edit_custom_tag.tagReplacement.DeleteAndCreate;
 
 import java.util.Map;
 
@@ -38,7 +39,7 @@ class EditTagInteractorTest {
             }
         };
 
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, new DeleteAndCreate());
         final EditTagController controller = new EditTagController(tagDao, manageTagsViewModel, interactor);
 
         final CustomTag oldTag = new CustomTag("home", CustomTagIcons.HOUSE);
@@ -73,7 +74,7 @@ class EditTagInteractorTest {
             }
         };
 
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, new DeleteAndCreate());
         final EditTagController controller = new EditTagController(tagDao, manageTagsViewModel, interactor);
 
         final CustomTag oldTag = new CustomTag("home", CustomTagIcons.HOUSE);
@@ -105,7 +106,7 @@ class EditTagInteractorTest {
             }
         };
 
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, new DeleteAndCreate());
         final EditTagController controller = new EditTagController(tagDao, manageTagsViewModel, interactor);
 
         final CustomTag oldTag = new CustomTag("home", CustomTagIcons.HOUSE);
@@ -139,7 +140,7 @@ class EditTagInteractorTest {
             }
         };
 
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, new DeleteAndCreate());
         final EditTagController controller = new EditTagController(tagDao, manageTagsViewModel, interactor);
 
         final CustomTag tagA = new CustomTag("home", CustomTagIcons.HOUSE);
@@ -173,7 +174,7 @@ class EditTagInteractorTest {
             }
         };
 
-        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter);
+        final EditTagInputBoundary interactor = new EditTagInteractor(tagDao, presenter, new DeleteAndCreate());
         final EditTagController controller = new EditTagController(tagDao, manageTagsViewModel, interactor);
 
         final CustomTag tagA = new CustomTag("home", CustomTagIcons.HOUSE);


### PR DESCRIPTION
**NEW**

- Refactored the execute method for the EditTagInteractor so that it depends on the implementation of an abstract interface (TagReplacementStrategy) for handling the logic of replacing tags within the Tag DAO. Additional classes that implement TagReplacementStrategy can be created for handling the tag replacement logic differently (currently we are using a delete-and-replace strategy, though an in-place replacement strategy could also be used, if needed).
- The replacementStrategy class is initialized as a field in appBuilder, and is inserted as a parameter in the EditTagInteractor. This way, changing the logic becomes as simple as changing a single line (field where its initialized) in the appBuilder--as compared to modifying the logic in the execute method of the interactor.
- This approach demonstrates the Dependency Inversion Principle, the Open-Closed Principle, and the Interface-Segregation Principle.